### PR TITLE
Add basic Pomodoro timer service using Glyph Matrix

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,5 +22,8 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <service
+            android:name=".service.PomodoroService"
+            android:exported="false" />
     </application>
 </manifest>

--- a/app/src/main/java/com/example/pomodoro/MainActivity.kt
+++ b/app/src/main/java/com/example/pomodoro/MainActivity.kt
@@ -1,16 +1,24 @@
 package com.example.pomodoro
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.example.pomodoro.service.PomodoroService
 import com.example.pomodoro.ui.theme.PomodoroTheme
 
 class MainActivity : ComponentActivity() {
@@ -19,29 +27,61 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             PomodoroTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    Greeting(
-                        name = "Android",
-                        modifier = Modifier.padding(innerPadding)
-                    )
+                Scaffold { innerPadding ->
+                    PomodoroScreen(modifier = Modifier.padding(innerPadding))
                 }
             }
         }
     }
-}
 
-@Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier
-    )
-}
+    private fun startServiceWithMinutes(minutes: Int) {
+        val duration = minutes * 60_000L
+        val intent = Intent(this, PomodoroService::class.java).apply {
+            putExtra(PomodoroService.EXTRA_DURATION, duration)
+        }
+        startService(intent)
+    }
 
-@Preview(showBackground = true)
-@Composable
-fun GreetingPreview() {
-    PomodoroTheme {
-        Greeting("Android")
+    private fun stopPomodoroService() {
+        val intent = Intent(this, PomodoroService::class.java)
+        stopService(intent)
+    }
+
+    @Composable
+    private fun PomodoroScreen(modifier: Modifier = Modifier) {
+        val minuteText = remember { mutableStateOf("25") }
+        val running = remember { mutableStateOf(false) }
+        Column(modifier.padding(16.dp)) {
+            OutlinedTextField(
+                value = minuteText.value,
+                onValueChange = { minuteText.value = it.filter { ch -> ch.isDigit() } },
+                label = { Text("Minutes") },
+                enabled = !running.value,
+                modifier = Modifier.fillMaxWidth()
+            )
+            Button(
+                onClick = {
+                    if (running.value) {
+                        stopPomodoroService()
+                    } else {
+                        val minutes = minuteText.value.toIntOrNull() ?: 25
+                        startServiceWithMinutes(minutes)
+                    }
+                    running.value = !running.value
+                },
+                modifier = Modifier.padding(top = 16.dp)
+            ) {
+                Text(if (running.value) "Stop" else "Start")
+            }
+        }
+    }
+
+    @Preview(showBackground = true)
+    @Composable
+    fun DefaultPreview() {
+        PomodoroTheme {
+            PomodoroScreen()
+        }
     }
 }
+

--- a/app/src/main/java/com/example/pomodoro/service/PomodoroService.kt
+++ b/app/src/main/java/com/example/pomodoro/service/PomodoroService.kt
@@ -1,0 +1,90 @@
+package com.example.pomodoro.service
+
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.os.IBinder
+import com.nothing.ketchum.Glyph
+import com.nothing.ketchum.GlyphMatrixFrame
+import com.nothing.ketchum.GlyphMatrixManager
+import com.nothing.ketchum.GlyphMatrixObject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+
+class PomodoroService : Service() {
+
+    private var glyphMatrixManager: GlyphMatrixManager? = null
+    private val gmmCallback = object : GlyphMatrixManager.Callback {
+        override fun onServiceConnected(name: android.content.ComponentName?) {
+            glyphMatrixManager?.register(Glyph.DEVICE_23112)
+            startCountdown()
+        }
+
+        override fun onServiceDisconnected(name: android.content.ComponentName?) {}
+    }
+
+    private var durationMillis: Long = 0L
+    private var countdownJob: Job? = null
+    private val serviceScope = CoroutineScope(Dispatchers.Default)
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        durationMillis = intent?.getLongExtra(EXTRA_DURATION, 0L) ?: 0L
+        GlyphMatrixManager.getInstance(applicationContext)?.let { gmm ->
+            glyphMatrixManager = gmm
+            gmm.init(gmmCallback)
+        }
+        return START_NOT_STICKY
+    }
+
+    private fun startCountdown() {
+        countdownJob?.cancel()
+        if (durationMillis <= 0L) return
+        countdownJob = serviceScope.launch {
+            var remaining = durationMillis
+            while (remaining >= 0 && isActive) {
+                postTime(remaining)
+                delay(1000L)
+                remaining -= 1000L
+            }
+            stopSelf()
+        }
+    }
+
+    private fun postTime(timeMs: Long) {
+        glyphMatrixManager?.let { manager ->
+            val totalSeconds = timeMs / 1000
+            val minutes = totalSeconds / 60
+            val seconds = totalSeconds % 60
+            val text = String.format("%02d:%02d", minutes, seconds)
+            val textObject = GlyphMatrixObject.Builder()
+                .setText(text)
+                .setPosition(2, 12)
+                .build()
+            val frame = GlyphMatrixFrame.Builder()
+                .addTop(textObject)
+                .build(applicationContext)
+            manager.setMatrixFrame(frame.render())
+        }
+    }
+
+    override fun onDestroy() {
+        countdownJob?.cancel()
+        serviceScope.cancel()
+        glyphMatrixManager?.turnOff()
+        glyphMatrixManager?.unInit()
+        glyphMatrixManager = null
+        super.onDestroy()
+    }
+
+    companion object {
+        const val EXTRA_DURATION = "extra_duration"
+    }
+}
+


### PR DESCRIPTION
## Summary
- create `PomodoroService` to drive Glyph Matrix countdown
- add simple Compose UI to start/stop timer
- register new service in `AndroidManifest`

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889706d0014832ebbe2b8670e550784