### PR TITLE
Implement glyph toy timer features

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,6 +24,19 @@
         </activity>
         <service
             android:name=".service.PomodoroService"
-            android:exported="false" />
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.nothing.glyph.TOY"/>
+            </intent-filter>
+            <meta-data
+                android:name="com.nothing.glyph.toy.name"
+                android:resource="@string/app_name"/>
+            <meta-data
+                android:name="com.nothing.glyph.toy.image"
+                android:resource="@mipmap/ic_launcher"/>
+            <meta-data
+                android:name="com.nothing.glyph.toy.longpress"
+                android:value="1"/>
+        </service>
     </application>
 </manifest>

--- a/app/src/main/java/com/example/pomodoro/MainActivity.kt
+++ b/app/src/main/java/com/example/pomodoro/MainActivity.kt
@@ -8,6 +8,8 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.Alignment
 import androidx.compose.material3.Button
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
@@ -51,7 +53,20 @@ class MainActivity : ComponentActivity() {
     private fun PomodoroScreen(modifier: Modifier = Modifier) {
         val minuteText = remember { mutableStateOf("25") }
         val running = remember { mutableStateOf(false) }
-        Column(modifier.padding(16.dp)) {
+        Column(
+            modifier = modifier.padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = "Pomodoro Timer",
+                style = MaterialTheme.typography.headlineMedium,
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
+            Text(
+                text = "Stay focused! \uD83C\uDF45",
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.padding(bottom = 16.dp)
+            )
             OutlinedTextField(
                 value = minuteText.value,
                 onValueChange = { minuteText.value = it.filter { ch -> ch.isDigit() } },

--- a/app/src/main/java/com/example/pomodoro/service/PomodoroService.kt
+++ b/app/src/main/java/com/example/pomodoro/service/PomodoroService.kt
@@ -1,10 +1,11 @@
 package com.example.pomodoro.service
 
-import android.app.Service
 import android.content.Context
 import android.content.Intent
-import android.os.IBinder
-import com.nothing.ketchum.Glyph
+import android.media.Ringtone
+import android.media.RingtoneManager
+import android.net.Uri
+import com.example.pomodoro.demos.GlyphMatrixService
 import com.nothing.ketchum.GlyphMatrixFrame
 import com.nothing.ketchum.GlyphMatrixManager
 import com.nothing.ketchum.GlyphMatrixObject
@@ -16,31 +17,30 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 
-class PomodoroService : Service() {
+class PomodoroService : GlyphMatrixService("Pomodoro") {
 
-    private var glyphMatrixManager: GlyphMatrixManager? = null
-    private val gmmCallback = object : GlyphMatrixManager.Callback {
-        override fun onServiceConnected(name: android.content.ComponentName?) {
-            glyphMatrixManager?.register(Glyph.DEVICE_23112)
-            startCountdown()
-        }
-
-        override fun onServiceDisconnected(name: android.content.ComponentName?) {}
-    }
-
-    private var durationMillis: Long = 0L
+    private var durationMillis: Long = DEFAULT_DURATION
     private var countdownJob: Job? = null
+    private var ringtone: Ringtone? = null
     private val serviceScope = CoroutineScope(Dispatchers.Default)
 
-    override fun onBind(intent: Intent?): IBinder? = null
+    override fun onBind(intent: Intent?) = super.onBind(intent)
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        durationMillis = intent?.getLongExtra(EXTRA_DURATION, 0L) ?: 0L
-        GlyphMatrixManager.getInstance(applicationContext)?.let { gmm ->
-            glyphMatrixManager = gmm
-            gmm.init(gmmCallback)
-        }
+        durationMillis = intent?.getLongExtra(EXTRA_DURATION, DEFAULT_DURATION) ?: DEFAULT_DURATION
         return START_NOT_STICKY
+    }
+
+    override fun performOnServiceConnected(context: Context, glyphMatrixManager: GlyphMatrixManager) {
+        startCountdown()
+    }
+
+    override fun performOnServiceDisconnected(context: Context) {
+        stopCountdown()
+    }
+
+    override fun onTouchPointLongPress() {
+        startCountdown()
     }
 
     private fun startCountdown() {
@@ -53,8 +53,15 @@ class PomodoroService : Service() {
                 delay(1000L)
                 remaining -= 1000L
             }
+            playAlarm()
             stopSelf()
         }
+    }
+
+    private fun stopCountdown() {
+        countdownJob?.cancel()
+        countdownJob = null
+        glyphMatrixManager?.turnOff()
     }
 
     private fun postTime(timeMs: Long) {
@@ -62,29 +69,41 @@ class PomodoroService : Service() {
             val totalSeconds = timeMs / 1000
             val minutes = totalSeconds / 60
             val seconds = totalSeconds % 60
-            val text = String.format("%02d:%02d", minutes, seconds)
-            val textObject = GlyphMatrixObject.Builder()
-                .setText(text)
-                .setPosition(2, 12)
+            val minutesText = String.format("%02d", minutes)
+            val secondsText = String.format("%02d", seconds)
+            val minutesObject = GlyphMatrixObject.Builder()
+                .setText(minutesText)
+                .setPosition(2, 6)
+                .build()
+            val secondsObject = GlyphMatrixObject.Builder()
+                .setText(secondsText)
+                .setPosition(2, 17)
                 .build()
             val frame = GlyphMatrixFrame.Builder()
-                .addTop(textObject)
+                .addTop(minutesObject)
+                .addLow(secondsObject)
                 .build(applicationContext)
             manager.setMatrixFrame(frame.render())
         }
     }
 
+    private fun playAlarm() {
+        if (ringtone == null) {
+            val alarmUri: Uri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_ALARM)
+            ringtone = RingtoneManager.getRingtone(applicationContext, alarmUri)
+        }
+        ringtone?.play()
+    }
+
     override fun onDestroy() {
-        countdownJob?.cancel()
+        stopCountdown()
         serviceScope.cancel()
-        glyphMatrixManager?.turnOff()
-        glyphMatrixManager?.unInit()
-        glyphMatrixManager = null
         super.onDestroy()
     }
 
     companion object {
         const val EXTRA_DURATION = "extra_duration"
+        private const val DEFAULT_DURATION = 25 * 60_000L
     }
 }
 


### PR DESCRIPTION
## Summary
- display minutes and seconds on separate rows
- play alarm when timer finishes
- enhance home screen with title and emoji
- register timer as a Glyph Toy service with long press support

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688977720d28832eba280ee45ca44554